### PR TITLE
Command line uniformity, ttys off by default on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "copy-paste": "^1.1.4",
     "get-stdin": "^5.0.1",
     "inquirer": "^0.12.0",
-    "minimist": "^1.2.0",
-    "ttys": "0.0.3"
+    "ttys": "0.0.3",
+    "yargs": "^4.8.0"
   },
   "devDependencies": {
     "ava": "^0.11.0",

--- a/src/index.js
+++ b/src/index.js
@@ -4,31 +4,9 @@ var os = require('os');
 
 var clipboard = require('copy-paste').copy;
 var inquirer = require('inquirer');
-var pkg = require('../package');
 var patchCliCursor = require('./patch-cli-cursor');
 
-module.exports = function ipt(p, ttys, log, options, input, error) {
-	function printHelp() {
-		log.info(
-			'\nUsage:\n  ipt [<path>]\n' +
-			'\nSpecify a file <path> or pipe some data from stdin to start interacting.\n' +
-			'\nOptions:\n' +
-			'  -v --version       Displays app version number\n' +
-			'  -h --help          Shows this help message\n' +
-			'  -d --debug         Prints original node error messages to stderr on errors\n' +
-			'  -e --file-encoding Sets a encoding to open <path> file, defaults to utf8\n' +
-			'  -m --multiple      Allows the selection of multiple items\n' +
-			'  -s --separator     Defines a separator to be used to split input into items\n' +
-			'  -c --copy          Copy selected item(s) to clipboard\n'
-		);
-		p.exit(0);
-	}
-
-	function printVersion() {
-		log.info(pkg.version);
-		p.exit(0);
-	}
-
+module.exports = function ipt(p, ttys, log, options, input) {
 	function end(data) {
 		if (!Array.isArray(data)) {
 			data = [data];
@@ -116,17 +94,15 @@ module.exports = function ipt(p, ttys, log, options, input, error) {
 		);
 	}
 
-	if (options.help) {
-		printHelp();
-	} else if (options.version) {
-		printVersion();
-	} else if (!input) {
-		printHelp();
+	if (!input) {
+		throw new Error('Input is missing');
 	} else {
 		try {
 			return showList();
 		} catch (err) {
-			error(err, 'An error occurred while building the interactive interface');
+			var err2 = new Error('An error occurred while building the interactive interface');
+			err2.subError = err;
+			throw err2;
 		}
 	}
 };

--- a/test/index.js
+++ b/test/index.js
@@ -4,13 +4,11 @@ import tempfile from 'tempfile';
 import {spawn} from 'child_process';
 import {copy, paste} from 'copy-paste';
 import ipt from '../src';
-import pkg from '../package.json';
 
 // Mocked deps
 const noop = function () {};
 const obj = Object.freeze({});
 const cwd = process.cwd();
-const helpMessageOutput = '\nUsage:\n  ipt [<path>]\n\nSpecify a file <path> or pipe some data from stdin to start interacting.\n\nOptions:\n  -v --version       Displays app version number\n  -h --help          Shows this help message\n  -d --debug         Prints original node error messages to stderr on errors\n  -e --file-encoding Sets a encoding to open <path> file, defaults to utf8\n  -m --multiple      Allows the selection of multiple items\n  -s --separator     Defines a separator to be used to split input into items\n  -c --copy          Copy selected item(s) to clipboard\n\n';
 
 function getConsoleOutput(str) {
 	const inquirerReleaseOutputCode = '\u001b[?25h';
@@ -39,33 +37,6 @@ test.beforeEach(t => {
 test.afterEach(t => {
 	t.context.p = null;
 	t.context.ttys = null;
-});
-
-test.cb('should display help message if no input provided', t => {
-	ipt(t.context.p, t.context.ttys, {
-		info: msg => {
-			t.is(msg.slice(0, 23), '\nUsage:\n  ipt [<path>]\n');
-			t.end();
-		}
-	}, obj);
-});
-
-test.cb('should display help message on help option', t => {
-	ipt(t.context.p, t.context.ttys, {
-		info: msg => {
-			t.is(msg.slice(0, 23), '\nUsage:\n  ipt [<path>]\n');
-			t.end();
-		}
-	}, Object.assign({}, obj, {help: true}));
-});
-
-test.cb('should display version number', t => {
-	ipt(t.context.p, t.context.ttys, {
-		info: msg => {
-			t.is(msg, pkg.version.toString());
-			t.end();
-		}
-	}, Object.assign({}, {version: true}));
 });
 
 test.cb('should build and select items from a basic list', t => {
@@ -296,57 +267,6 @@ test.cb('should run other different encoding using --file-encoding option', t =>
 		t.end();
 	});
 	run.stdin.write('\n');
-	run.stdin.end();
-});
-
-test.cb('should display help message on --help', t => {
-	let content = '';
-	let run = spawn('node', ['../src/cli.js', './fixtures/simpletest', '--no-ttys=true', '-n', '--help'], {
-		cwd: cwd,
-		stdio: ['pipe', 'pipe', 'inherit']
-	});
-	run.stdout.on('data', data => {
-		content += data.toString();
-	});
-	run.on('close', code => {
-		t.is(code, 0);
-		t.is(content, helpMessageOutput);
-		t.end();
-	});
-	run.stdin.end();
-});
-
-test.cb('should display help message on empty invocation', t => {
-	let content = '';
-	let run = spawn('node', ['../src/cli.js'], {
-		cwd: cwd,
-		stdio: ['pipe', 'pipe', 'inherit']
-	});
-	run.stdout.on('data', data => {
-		content += data.toString();
-	});
-	run.on('close', code => {
-		t.is(code, 0);
-		t.is(content, helpMessageOutput);
-		t.end();
-	});
-	run.stdin.end();
-});
-
-test.cb('should display version on --version', t => {
-	let content = '';
-	let run = spawn('node', ['../src/cli.js', './fixtures/simpletest', '--no-ttys=true', '-n', '--version'], {
-		cwd: cwd,
-		stdio: ['pipe', 'pipe', 'inherit']
-	});
-	run.stdout.on('data', data => {
-		content += data.toString();
-	});
-	run.on('close', code => {
-		t.is(code, 0);
-		t.is(content, pkg.version.toString() + '\n');
-		t.end();
-	});
 	run.stdin.end();
 });
 


### PR DESCRIPTION
There were too many discrepancies in the help message since it was hardcoded and too far from the definition.
Yargs gives nice tools for better command line handling.
Removed manual handling of `--help` and `--version`
Removed command line tests 

The `ttys` module crashes on Windows (see https://github.com/TooTallNate/ttys/issues/1)
Require it on demand and off by default on Windows

There are still a number of issues on Windows, but with this I at least get to run it.
The issue I see left is the prompt is not interactive when piping, works with a file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ruyadorno/ipt/8)
<!-- Reviewable:end -->
