### PR TITLE
Supports node LTS+ only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 'stable'
-  - '0.12'
+  - 'node'
+  - 'lts/*'

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Install it easily using **npm**:
 $ npm install -g ipt
 ```
 
-_Keep in mind that you'll need to have at least **Node.js** > 0.12 installed_
+_Keep in mind that you'll need the latest **Node.js** LTS installed_
 
 ### Beginners Setup
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bin": "src/cli.js",
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "pretest": "xo",


### PR DESCRIPTION
- From now on master will only support node LTS+ versions
- Support to legacy node may continue on branch v1.x.x
- Updated package.json and travis to reflect changes on policy