### PR TITLE
Replace ttys

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,23 +35,28 @@
   "dependencies": {
     "clipboardy": "^1.2.2",
     "fuzzysearch": "^1.0.3",
-    "get-stdin": "^5.0.1",
-    "inquirer": "^4.0.2",
+    "get-stdin": "^6.0.0",
+    "inquirer": "^5.0.1",
     "inquirer-autocomplete-prompt": "^0.12.1",
     "minimist": "^1.2.0",
     "reopen-tty": "^1.1.1"
   },
   "devDependencies": {
-    "ava": "^0.24.0",
+    "ava": "^1.0.0-beta.3",
     "lodash.template": "^4.4.0",
-    "mock-require": "^2.0.2",
+    "mock-require": "^3.0.1",
     "tempfile": "^2.0.0",
-    "xo": "^0.18.2"
+    "xo": "^0.20.3"
+  },
+  "ava": {
+    "babel": false,
+    "compileEnhancements": false
   },
   "xo": {
     "rules": {
       "no-negated-condition": 0,
-      "ava/test-ended": 0
+      "ava/test-ended": 0,
+      "promise/prefer-await-to-then": 0
     }
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -39,17 +39,19 @@
     "inquirer": "^4.0.2",
     "inquirer-autocomplete-prompt": "^0.12.1",
     "minimist": "^1.2.0",
-    "ttys": "0.0.3"
+    "reopen-tty": "^1.1.1"
   },
   "devDependencies": {
     "ava": "^0.24.0",
+    "lodash.template": "^4.4.0",
     "mock-require": "^2.0.2",
     "tempfile": "^2.0.0",
     "xo": "^0.18.2"
   },
   "xo": {
     "rules": {
-      "no-negated-condition": 0
+      "no-negated-condition": 0,
+      "ava/test-ended": 0
     }
   },
   "license": "MIT"

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,8 +3,9 @@
 'use strict';
 
 const fs = require('fs');
+const {promisify} = require('util');
 const getStdin = require('get-stdin');
-const ttys = require('ttys');
+const reopenTTY = require('reopen-tty');
 const argv = require('minimist')(process.argv.slice(2), {
 	boolean: [
 		'autocomplete',
@@ -39,7 +40,19 @@ process.stdin.on('keypress', (ch, key) => {
 });
 
 function startIpt(input) {
-	require('./')(process, (argv['no-ttys'] ? process : ttys), console, argv, input, error);
+	Promise.all([
+		promisify(reopenTTY.stdin)(),
+		promisify(reopenTTY.stdout)(),
+		promisify(reopenTTY.stderr)()
+	])
+		.then(stdio => {
+			const [stdin, stdout, stderr] = stdio;
+			const istdin = argv['stdin-tty'] ? fs.createReadStream(argv['stdin-tty']) : stdin;
+			require('./')(process, (argv['no-ttys'] ? process : {stdin: istdin, stdout, stderr}), console, argv, input, error);
+		})
+		.catch(err => {
+			console.error(argv.debug ? err : 'Error opening tty interaction');
+		});
 }
 
 function error(e, msg) {
@@ -47,20 +60,12 @@ function error(e, msg) {
 	process.exit(1);
 }
 
-if (filePath) {
-	fs.readFile(filePath, {
+(filePath ?
+	promisify(fs.readFile)(filePath, {
 		encoding: argv['file-encoding'] || 'utf8'
-	}, (err, data) => {
-		if (err) {
-			error(err, 'Error reading file from path');
-		} else {
-			startIpt(data);
-		}
+	}) :
+	getStdin())
+	.then(data => startIpt(data))
+	.catch(err => {
+		error(err, 'Error reading incoming data');
 	});
-} else {
-	getStdin().then(data => {
-		startIpt(data);
-	}).catch(err => {
-		error(err, 'Error while reading stdin');
-	});
-}

--- a/src/cli.js
+++ b/src/cli.js
@@ -30,7 +30,7 @@ const argv = require('minimist')(process.argv.slice(2), {
 	}
 });
 
-const filePath = argv._[0];
+const [filePath] = argv._;
 
 // Exits program execution on ESC or q keypress
 process.stdin.on('keypress', (ch, key) => {
@@ -47,8 +47,8 @@ function startIpt(input) {
 	])
 		.then(stdio => {
 			const [stdin, stdout, stderr] = stdio;
-			const istdin = argv['stdin-tty'] ? fs.createReadStream(argv['stdin-tty']) : stdin;
-			require('./')(process, (argv['no-ttys'] ? process : {stdin: istdin, stdout, stderr}), console, argv, input, error);
+			const getStdin = () => argv['stdin-tty'] ? fs.createReadStream(argv['stdin-tty']) : stdin;
+			require('.')(process, (argv['no-ttys'] ? process : {stdin: getStdin(), stdout, stderr}), console, argv, input, error);
 		})
 		.catch(err => {
 			console.error(argv.debug ? err : 'Error opening tty interaction');

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ module.exports = function (p, ttys, log, options, input, error) {
 			ttys.stdout.destroy();
 		}
 		// Release cursor by printing to sdterr
-		log.warn('\u001b[?25h');
+		log.warn('\u001B[?25h');
 		p.exit(0);
 	}
 


### PR DESCRIPTION
- Replaced `ttys` with `reopen-tty`
- Updated dependencies and dev dependencies
- Disables **babel** transpilation for `ava`
- Refactors to use `util.promisify` in order to have better standard promise support
- Refactored cli tests