### PR TITLE
Replaced minimist by yargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,22 +129,23 @@ source ~/.bashrc
 ## Help
 
 ```sh
+
 Usage:
   ipt [options] [<path>]
 
-Specify a file <path> or pipe some data from stdin to start interacting.
-
 Options:
-  -v --version       Displays app version number
-  -h --help          Shows this help message
-  -a --autocomplete  Starts interactive selection in autocomplete mode
-  -d --debug         Prints original node error messages to stderr on errors
-  -e --file-encoding Sets a encoding to open <path> file, defaults to utf8
-  -m --multiple      Allows the selection of multiple items
-  -s --separator     Defines a separator to be used to split input into items
-  -c --copy          Do not copy selected item(s) to clipboard
-  -t --no-trim       Prevents trimming of the result strings
-  --unquoted         Force the output to be unquoted
+  -a, --autocomplete   Starts in autocomplete mode                     [boolean]
+  -c, --copy           Copy selected item(s) to clipboard              [boolean]
+  -d, --debug          Prints to stderr any internal error             [boolean]
+  -e, --file-encoding  Encoding for file <path>, defaults to utf8       [string]
+  -h, --help           Shows this help message                         [boolean]
+  -m, --multiple       Allows the selection of multiple items          [boolean]
+  -s, --separator      Separator to to split input into items           [string]
+  -t, --no-trim        Prevents trimming of the result strings         [boolean]
+  -p, --extract-path   Returns only a valid path for each item         [boolean]
+  -u, --unquoted       Force the output to be unquoted                 [boolean]
+  -v, --version        Show version number                             [boolean]
+
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "get-stdin": "^6.0.0",
     "inquirer": "^5.0.1",
     "inquirer-autocomplete-prompt": "^0.12.1",
-    "minimist": "^1.2.0",
-    "reopen-tty": "^1.1.1"
+    "reopen-tty": "^1.1.1",
+    "yargs": "^11.0.0"
   },
   "devDependencies": {
     "ava": "^1.0.0-beta.3",

--- a/src/index.js
+++ b/src/index.js
@@ -5,34 +5,9 @@ const os = require('os');
 const clipboard = require('clipboardy').write;
 const inquirer = require('inquirer');
 const fuzzysearch = require('fuzzysearch');
-const pkg = require('../package');
 
 module.exports = function (p, ttys, log, options, input, error) {
 	const sep = options.separator || os.EOL;
-	function printHelp() {
-		log.info(
-			'\nUsage:\n  ipt [options] [<path>]\n' +
-			'\nSpecify a file <path> or pipe some data from stdin to start interacting.\n' +
-			'\nOptions:\n' +
-			'  -v --version       Displays app version number\n' +
-			'  -h --help          Shows this help message\n' +
-			'  -a --autocomplete  Starts interactive selection in autocomplete mode\n' +
-			'  -d --debug         Prints original node error messages to stderr on errors\n' +
-			'  -e --file-encoding Sets a encoding to open <path> file, defaults to utf8\n' +
-			'  -m --multiple      Allows the selection of multiple items\n' +
-			'  -s --separator     Defines a separator to be used to split input into items\n' +
-			'  -c --copy          Copy selected item(s) to clipboard\n' +
-			'  -t --no-trim       Prevents trimming of the result strings\n' +
-			'  -p --extract-path  Returns only a valid path within each input item\n' +
-			'  --unquoted         Force the output to be unquoted\n'
-		);
-		p.exit(0);
-	}
-
-	function printVersion() {
-		log.info(pkg.version);
-		p.exit(0);
-	}
 
 	function end(data) {
 		if (!Array.isArray(data)) {
@@ -138,18 +113,10 @@ module.exports = function (p, ttys, log, options, input, error) {
 		return result.ui;
 	}
 
-	const showHelp = options.help || !input;
-
-	if (options.version) {
-		printVersion();
-	} else if (showHelp) {
-		printHelp();
-	} else {
-		try {
-			return showList();
-		} catch (err) {
-			error(err, 'An error occurred while building the interactive interface');
-		}
+	try {
+		return showList();
+	} catch (err) {
+		error(err, 'An error occurred while building the interactive interface');
 	}
 };
 

--- a/test/fixtures/help
+++ b/test/fixtures/help
@@ -1,19 +1,23 @@
-
 Usage:
   ipt [options] [<path>]
 
-Specify a file <path> or pipe some data from stdin to start interacting.
-
 Options:
-  -v --version       Displays app version number
-  -h --help          Shows this help message
-  -a --autocomplete  Starts interactive selection in autocomplete mode
-  -d --debug         Prints original node error messages to stderr on errors
-  -e --file-encoding Sets a encoding to open <path> file, defaults to utf8
-  -m --multiple      Allows the selection of multiple items
-  -s --separator     Defines a separator to be used to split input into items
-  -c --copy          Copy selected item(s) to clipboard
-  -t --no-trim       Prevents trimming of the result strings
-  -p --extract-path  Returns only a valid path within each input item
-  --unquoted         Force the output to be unquoted
+  -a, --autocomplete   Starts in autocomplete mode                     [boolean]
+  -c, --copy           Copy selected item(s) to clipboard              [boolean]
+  -d, --debug          Prints to stderr any internal error             [boolean]
+  -e, --file-encoding  Encoding for file <path>, defaults to utf8       [string]
+  -h, --help           Shows this help message                         [boolean]
+  -m, --multiple       Allows the selection of multiple items          [boolean]
+  -s, --separator      Separator to to split input into items           [string]
+  -t, --no-trim        Prevents trimming of the result strings         [boolean]
+  -p, --extract-path   Returns only a valid path for each item         [boolean]
+  -u, --unquoted       Force the output to be unquoted                 [boolean]
+  -v, --version        Show version number                             [boolean]
+
+Examples:
+  ls | ipt         Builds an interactive interface out of current dir items
+  cat $(ls | ipt)  Uses cat to print contents of whatever item is selected
+  ipt ./file       Builds the interactive list out of a given file
+
+Visit https://github.com/ruyadorno/ipt for more info
 

--- a/test/index.js
+++ b/test/index.js
@@ -57,33 +57,6 @@ test.afterEach(t => {
 	t.context.ttys = null;
 });
 
-test.cb('should display help message if no input provided', t => {
-	ipt(t.context.p, t.context.ttys, {
-		info: msg => {
-			t.is(msg.slice(0, 33), '\nUsage:\n  ipt [options] [<path>]\n');
-			t.end();
-		}
-	}, obj);
-});
-
-test.cb('should display help message on help option', t => {
-	ipt(t.context.p, t.context.ttys, {
-		info: msg => {
-			t.is(msg.slice(0, 33), '\nUsage:\n  ipt [options] [<path>]\n');
-			t.end();
-		}
-	}, Object.assign({}, obj, {help: true}));
-});
-
-test.cb('should display version number', t => {
-	ipt(t.context.p, t.context.ttys, {
-		info: msg => {
-			t.is(msg, pkg.version.toString());
-			t.end();
-		}
-	}, Object.assign({}, {version: true}));
-});
-
 test.cb('should build and select items from a basic list', t => {
 	const prompt = ipt(t.context.p, t.context.ttys, {
 		info: msg => {


### PR DESCRIPTION
- Replaced minimist by yargs
- More refactors, removed `printHelp()`, `printVersion()` methods from `src/index.js` now all that logic lives only in `src/cli.js`
