### PR TITLE
Add option to select default choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Options:
   -a, --autocomplete   Starts in autocomplete mode                     [boolean]
   -c, --copy           Copy selected item(s) to clipboard              [boolean]
   -d, --debug          Prints to stderr any internal error             [boolean]
+  -D, --default        Select a default choice by its name              [string]
   -e, --file-encoding  Encoding for file <path>, defaults to utf8       [string]
   -h, --help           Shows this help message                         [boolean]
   -m, --multiple       Allows the selection of multiple items          [boolean]

--- a/README.md
+++ b/README.md
@@ -186,21 +186,23 @@ Usage:
   ipt [options] [<path>]
 
 Options:
-  -0, --null           Uses a null character as separator              [boolean]
-  -a, --autocomplete   Starts in autocomplete mode                     [boolean]
-  -c, --copy           Copy selected item(s) to clipboard              [boolean]
-  -d, --debug          Prints to stderr any internal error             [boolean]
-  -D, --default        Select a default choice by its name              [string]
-  -e, --file-encoding  Encoding for file <path>, defaults to utf8       [string]
-  -h, --help           Shows this help message                         [boolean]
-  -m, --multiple       Allows the selection of multiple items          [boolean]
-  -M, --message        Replaces interface message                       [string]
-  -p, --extract-path   Returns only a valid path for each item         [boolean]
-  -s, --separator      Separator to to split input into items           [string]
-  -S, --size           Amount of lines to display at once               [number]
-  -t, --no-trim        Prevents trimming of the result strings         [boolean]
-  -u, --unquoted       Force the output to be unquoted                 [boolean]
-  -v, --version        Show version number                             [boolean]
+  -0, --null               Uses a null character as separator          [boolean]
+  -a, --autocomplete       Starts in autocomplete mode                 [boolean]
+  -c, --copy               Copy selected item(s) to clipboard          [boolean]
+  -d, --debug              Prints to stderr any internal error         [boolean]
+  -D, --default            Select a default choices by their name       [string]
+  -P, --default-separator  Separator to to split default choices into items,
+                           defaults to the separator                    [string]
+  -e, --file-encoding      Encoding for file <path>, defaults to utf8   [string]
+  -h, --help               Shows this help message                     [boolean]
+  -m, --multiple           Allows the selection of multiple items      [boolean]
+  -M, --message            Replaces interface message                   [string]
+  -p, --extract-path       Returns only a valid path for each item     [boolean]
+  -s, --separator          Separator to to split input into items       [string]
+  -S, --size               Amount of lines to display at once           [number]
+  -t, --no-trim            Prevents trimming of the result strings     [boolean]
+  -u, --unquoted           Force the output to be unquoted             [boolean]
+  -v, --version            Show version number                         [boolean]
 
 ```
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -31,6 +31,8 @@ const { argv } = yargs
 	.describe("c", "Copy selected item(s) to clipboard")
 	.alias("d", "debug")
 	.describe("d", "Prints to stderr any internal error")
+	.alias("D", "default")
+	.describe("D", "Select a default choice by its name")
 	.alias("e", "file-encoding")
 	.describe("e", "Encoding for file <path>, defaults to utf8")
 	.help("h")
@@ -54,7 +56,7 @@ const { argv } = yargs
 	.describe("u", "Force the output to be unquoted")
 	.alias("v", "version")
 	.boolean(["a", "c", "d", "h", "m", "0", "t", "p", "u", "v"])
-	.string(["e", "M", "s"])
+	.string(["e", "M", "s", "D"])
 	.number(["S"])
 	.epilog("Visit https://github.com/ruyadorno/ipt for more info");
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,7 +32,12 @@ const { argv } = yargs
 	.alias("d", "debug")
 	.describe("d", "Prints to stderr any internal error")
 	.alias("D", "default")
-	.describe("D", "Select a default choice by its name")
+	.describe("D", "Select a default choices by their name")
+	.alias("P", "default-separator")
+	.describe(
+		"P",
+		"Separator to to split default choices into items, defaults to the separator"
+	)
 	.alias("e", "file-encoding")
 	.describe("e", "Encoding for file <path>, defaults to utf8")
 	.help("h")
@@ -56,7 +61,7 @@ const { argv } = yargs
 	.describe("u", "Force the output to be unquoted")
 	.alias("v", "version")
 	.boolean(["a", "c", "d", "h", "m", "0", "t", "p", "u", "v"])
-	.string(["e", "M", "s", "D"])
+	.string(["e", "M", "s", "D", "P"])
 	.number(["S"])
 	.epilog("Visit https://github.com/ruyadorno/ipt for more info");
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const os = require("os");
 const cliWidth = require("cli-width");
 const inquirer = require("inquirer");
 const fuzzysearch = require("fuzzysearch");
@@ -29,14 +30,14 @@ function iPipeTo(
 	}
 
 	function getDefaultChoices(promptType) {
-		if (promptType.type === 'list') {
+		if (promptType.type === "list") {
 			return options.default;
 		}
 
-		if (promptType.type === 'checkbox') {
-			return options.default
-				.split(' ')
-				.map(name => name.trim());
+		if (promptType.type === "checkbox") {
+			return options.default.split(
+				options["default-separator"] || options.separator || os.EOL
+			);
 		}
 	}
 
@@ -98,7 +99,8 @@ function iPipeTo(
 		}
 	};
 
-	const promptType = (options.multiple && promptTypes.multiple) ||
+	const promptType =
+		(options.multiple && promptTypes.multiple) ||
 		(options.autocomplete && promptTypes.autocomplete) ||
 		promptTypes.base;
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,18 @@ function iPipeTo(
 		return str.length > maxWidth ? str.substr(0, maxWidth) + "..." : str;
 	}
 
+	function getDefaultChoices(promptType) {
+		if (promptType.type === 'list') {
+			return options.default;
+		}
+
+		if (promptType.type === 'checkbox') {
+			return options.default
+				.split(',')
+				.map(name => name.trim());
+		}
+	}
+
 	const prompt = inquirer.createPromptModule({
 		input: stdin,
 		output: stdout
@@ -86,11 +98,15 @@ function iPipeTo(
 		}
 	};
 
-	const result = prompt(
-		(options.multiple && promptTypes.multiple) ||
-			(options.autocomplete && promptTypes.autocomplete) ||
-			promptTypes.base
-	);
+	const promptType = (options.multiple && promptTypes.multiple) ||
+		(options.autocomplete && promptTypes.autocomplete) ||
+		promptTypes.base;
+
+	if (options.default) {
+		promptType.default = getDefaultChoices(promptType);
+	}
+
+	const result = prompt(promptType);
 
 	if (__prompt) {
 		__prompt.ui = result.ui;

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function iPipeTo(
 
 		if (promptType.type === 'checkbox') {
 			return options.default
-				.split(',')
+				.split(' ')
 				.map(name => name.trim());
 		}
 	}

--- a/test/fixtures/help
+++ b/test/fixtures/help
@@ -6,6 +6,7 @@ Options:
   -a, --autocomplete   Starts in autocomplete mode                     [boolean]
   -c, --copy           Copy selected item(s) to clipboard              [boolean]
   -d, --debug          Prints to stderr any internal error             [boolean]
+  -D, --default        Select a default choice by its name              [string]
   -e, --file-encoding  Encoding for file <path>, defaults to utf8       [string]
   -h, --help           Shows this help message                         [boolean]
   -m, --multiple       Allows the selection of multiple items          [boolean]

--- a/test/fixtures/help
+++ b/test/fixtures/help
@@ -2,21 +2,23 @@ Usage:
   ipt [options] [<path>]
 
 Options:
-  -0, --null           Uses a null character as separator              [boolean]
-  -a, --autocomplete   Starts in autocomplete mode                     [boolean]
-  -c, --copy           Copy selected item(s) to clipboard              [boolean]
-  -d, --debug          Prints to stderr any internal error             [boolean]
-  -D, --default        Select a default choice by its name              [string]
-  -e, --file-encoding  Encoding for file <path>, defaults to utf8       [string]
-  -h, --help           Shows this help message                         [boolean]
-  -m, --multiple       Allows the selection of multiple items          [boolean]
-  -M, --message        Replaces interface message                       [string]
-  -p, --extract-path   Returns only a valid path for each item         [boolean]
-  -s, --separator      Separator to to split input into items           [string]
-  -S, --size           Amount of lines to display at once               [number]
-  -t, --no-trim        Prevents trimming of the result strings         [boolean]
-  -u, --unquoted       Force the output to be unquoted                 [boolean]
-  -v, --version        Show version number                             [boolean]
+  -0, --null               Uses a null character as separator          [boolean]
+  -a, --autocomplete       Starts in autocomplete mode                 [boolean]
+  -c, --copy               Copy selected item(s) to clipboard          [boolean]
+  -d, --debug              Prints to stderr any internal error         [boolean]
+  -D, --default            Select a default choices by their name       [string]
+  -P, --default-separator  Separator to to split default choices into items,
+                           defaults to the separator                    [string]
+  -e, --file-encoding      Encoding for file <path>, defaults to utf8   [string]
+  -h, --help               Shows this help message                     [boolean]
+  -m, --multiple           Allows the selection of multiple items      [boolean]
+  -M, --message            Replaces interface message                   [string]
+  -p, --extract-path       Returns only a valid path for each item     [boolean]
+  -s, --separator          Separator to to split input into items       [string]
+  -S, --size               Amount of lines to display at once           [number]
+  -t, --no-trim            Prevents trimming of the result strings     [boolean]
+  -u, --unquoted           Force the output to be unquoted             [boolean]
+  -v, --version            Show version number                         [boolean]
 
 Examples:
   ls | ipt         Builds an interactive interface out of current dir items

--- a/test/index.js
+++ b/test/index.js
@@ -471,7 +471,7 @@ if (!process.env.APPVEYOR) {
 				"simpletest"
 			)} --stdin-tty=<%= stdin %> -D bar`,
 			input: ["k", "\n"],
-			output: 'foo'
+			output: "foo"
 		})
 	);
 

--- a/test/index.js
+++ b/test/index.js
@@ -482,7 +482,7 @@ if (!process.env.APPVEYOR) {
 				"test",
 				"fixtures",
 				"simpletest"
-			)} --stdin-tty=<%= stdin %> -m -D lorem,ipsum,sit`,
+			)} --stdin-tty=<%= stdin %> -m -D "lorem ipsum sit"`,
 			input: ["j", " ", "j", "j", " ", sep],
 			output: `bar${sep}lorem${sep}sit`
 		})

--- a/test/index.js
+++ b/test/index.js
@@ -482,9 +482,48 @@ if (!process.env.APPVEYOR) {
 				"test",
 				"fixtures",
 				"simpletest"
-			)} --stdin-tty=<%= stdin %> -m -D "lorem ipsum sit"`,
+			)} --stdin-tty=<%= stdin %> -m -D "lorem${sep}ipsum${sep}sit"`,
 			input: ["j", " ", "j", "j", " ", sep],
 			output: `bar${sep}lorem${sep}sit`
+		})
+	);
+
+	test.cb(
+		"should be able to use ---default-separator to split multiple default choices",
+		cli({
+			cmd: `node ${path.join("src", "cli.js")} ${path.join(
+				"test",
+				"fixtures",
+				"simpletest"
+			)} --stdin-tty=<%= stdin %> -m --default-separator=, -D "lorem,ipsum,sit"`,
+			input: ["j", " ", "j", "j", " ", sep],
+			output: `bar${sep}lorem${sep}sit`
+		})
+	);
+
+	test.cb(
+		"should be able use --separator as the default separator to split multiple default choices",
+		cli({
+			cmd: `node ${path.join("src", "cli.js")} ${path.join(
+				"test",
+				"fixtures",
+				"test.csv"
+			)} --stdin-tty=<%= stdin %> -m --separator=, -D "banana,mangoes"`,
+			input: ["j", " ", sep],
+			output: `banana,oranges,mangoes`
+		})
+	);
+
+	test.cb(
+		"should be able override --separator with --default-separator to split multiple default choices",
+		cli({
+			cmd: `node ${path.join("src", "cli.js")} ${path.join(
+				"test",
+				"fixtures",
+				"test.csv"
+			)} --stdin-tty=<%= stdin %> -m --separator=, --default-separator=: -D "banana:mangoes"`,
+			input: ["j", " ", sep],
+			output: `banana,oranges,mangoes`
 		})
 	);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -461,4 +461,30 @@ if (!process.env.APPVEYOR) {
 			output: "foo"
 		})
 	);
+
+	test.cb(
+		"should be able to specify a default selected option in a list",
+		cli({
+			cmd: `node ${path.join("src", "cli.js")} ${path.join(
+				"test",
+				"fixtures",
+				"simpletest"
+			)} --stdin-tty=<%= stdin %> -D bar`,
+			input: ["k", "\n"],
+			output: 'foo'
+		})
+	);
+
+	test.cb(
+		"should be able to specify a list of default choices to select for multiple choices",
+		cli({
+			cmd: `node ${path.join("src", "cli.js")} ${path.join(
+				"test",
+				"fixtures",
+				"simpletest"
+			)} --stdin-tty=<%= stdin %> -m -D lorem,ipsum,sit`,
+			input: ["j", " ", "j", "j", " ", sep],
+			output: `bar${sep}lorem${sep}sit`
+		})
+	);
 }


### PR DESCRIPTION
This PR adds a `default` option to allow certain items in a list to be selected by default.

For a single-choice list, it will select the given item defined in `default`. For a multi-choice list, it will select the given choices separated by space (` `) within quotations.

This is especially helpful in for example selecting the current branch in a list of branches:

```sh
$ git branch -a | ipt -D "$(git rev-parse --abbrev-ref HEAD)"
```

or for example auto-selecting already merged branches:

```sh
$ git branch -a | ipt -m -D "$(git branch -a --merged ${1-master} | xargs)"
```