### PR TITLE
Add docs for default-options

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ The `-c` or `--copy` option allows you to copy the selected item value to clipbo
 
 Customize your workflow by defining the separator to be used to generate the list (`-s` or `--separator` options), a custom message to display on the interactive interface (`-M` or `--message`) and much more. Make sure to take a look at the [Help](#help) section to learn about all the available options.
 
+### Default selected items
+
+Use the `-D` or `--default` option to determine which item(s) should be selected by default on the interactive list. The `-P` or `--default-separator` also allows for a custom char to be used to split these items (similar to `-s` option).
+
 ### Node.js based
 
 All you need in order to run **ipt** is the [Node.js](https://nodejs.org/en/) runtime and [npm](https://www.npmjs.com/), if you have those you're already all set!
@@ -191,8 +195,7 @@ Options:
   -c, --copy               Copy selected item(s) to clipboard          [boolean]
   -d, --debug              Prints to stderr any internal error         [boolean]
   -D, --default            Select a default choices by their name       [string]
-  -P, --default-separator  Separator to to split default choices into items,
-                           defaults to the separator                    [string]
+  -P, --default-separator  Separator element for default items          [string]
   -e, --file-encoding      Encoding for file <path>, defaults to utf8   [string]
   -h, --help               Shows this help message                     [boolean]
   -m, --multiple           Allows the selection of multiple items      [boolean]

--- a/src/cli.js
+++ b/src/cli.js
@@ -34,10 +34,7 @@ const { argv } = yargs
 	.alias("D", "default")
 	.describe("D", "Select a default choices by their name")
 	.alias("P", "default-separator")
-	.describe(
-		"P",
-		"Separator to to split default choices into items, defaults to the separator"
-	)
+	.describe( "P", "Separator element for default items")
 	.alias("e", "file-encoding")
 	.describe("e", "Encoding for file <path>, defaults to utf8")
 	.help("h")
@@ -72,7 +69,7 @@ if (nullOptIndex > -1) {
 	argv._.splice(nullOptIndex, 1);
 }
 
-const sep = argv.null ? "\u0000" : argv.separator || os.EOL;
+argv.separator = argv.null ? "\u0000" : argv.separator || os.EOL;
 const [filePath] = argv._;
 let { stdin, stdout } = process;
 
@@ -99,7 +96,7 @@ function error(e, msg) {
 }
 
 function end(data) {
-	process.stdout.write([].concat(data).join(sep) + (argv.null ? "" : "\n"));
+	process.stdout.write([].concat(data).join(argv.separator) + (argv.null ? "" : "\n"));
 	process.exit(0);
 }
 
@@ -129,7 +126,7 @@ function startIpt(input) {
 
 			const getStdin = () =>
 				argv["stdin-tty"] ? fs.createReadStream(argv["stdin-tty"]) : stdin;
-			return require(".")(input.split(sep), {
+			return require(".")(input.split(argv.separator), {
 				stdin: getStdin(),
 				stdout,
 				...argv
@@ -137,7 +134,7 @@ function startIpt(input) {
 		})
 		.then(
 			answers =>
-				argv.copy ? clipboard(answers.join(sep)).then(() => answers) : answers
+				argv.copy ? clipboard(answers.join(argv.separator)).then(() => answers) : answers
 		)
 		.then(end)
 		.catch(onForcedExit);

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ function iPipeTo(
 
 		if (promptType.type === "checkbox") {
 			return options.default.split(
-				options["default-separator"] || options.separator || os.EOL
+				options["default-separator"] || options.separator
 			);
 		}
 	}

--- a/test/fixtures/help
+++ b/test/fixtures/help
@@ -7,8 +7,7 @@ Options:
   -c, --copy               Copy selected item(s) to clipboard          [boolean]
   -d, --debug              Prints to stderr any internal error         [boolean]
   -D, --default            Select a default choices by their name       [string]
-  -P, --default-separator  Separator to to split default choices into items,
-                           defaults to the separator                    [string]
+  -P, --default-separator  Separator element for default items          [string]
   -e, --file-encoding      Encoding for file <path>, defaults to utf8   [string]
   -h, --help               Shows this help message                     [boolean]
   -m, --multiple           Allows the selection of multiple items      [boolean]


### PR DESCRIPTION
- Minor refactor to match `default-separator` to `separator` option by default
- Added docs for `default-options` on README