### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ os:
   - osx
 language: node_js
 node_js:
+  - '10'
   - 'node'
-  - 'lts/*'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1651,9 +1651,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.3.0.tgz",
-      "integrity": "sha512-EWaGjlDAZRzVFveh2Jsglcere2KK5CJBhkNSa1xs3KfMUGdRiT7lG089eqPdvlzWHpAqaekubOsOMu8W8Yk71A==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.4.0.tgz",
+      "integrity": "sha512-YrKucoFdc7SEko5Sxe4r6ixqXPDP1tunGw91POeZTTRKItf/AMFYt/YLEQtZMkR2LVpAVhcAcZgcWpm1oGPW7w==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -4368,9 +4368,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz",
-      "integrity": "sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
+      "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
       "requires": {
         "cliui": "^5.0.0",
         "decamelize": "^1.2.0",
@@ -4382,7 +4382,7 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^15.0.0"
       },
       "dependencies": {
         "string-width": {
@@ -4398,9 +4398,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,11 +1791,11 @@
       }
     },
     "extract-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/extract-path/-/extract-path-1.0.0.tgz",
-      "integrity": "sha512-FN9kpD3x8idqE8ILIJ/HvYR/jKlULE84ozBQQ4LH17l/kdpFH8Roko5Yx9uMT/94YTtAQ++1CtlZSL4a/XE1LA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/extract-path/-/extract-path-2.0.0.tgz",
+      "integrity": "sha512-EQrwJL8rfZti2iCL7NvXrK3AN6jh7SjgCfDfQyCeuL6nEzsbDEVfxMQzhZeTPjStLcoWzLbyddulJ01YaZjk4g==",
       "requires": {
-        "untildify": "^3.0.2"
+        "untildify": "^4.0.0"
       }
     },
     "fast-deep-equal": {
@@ -4189,9 +4189,9 @@
       }
     },
     "untildify": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
     },
     "update-notifier": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -493,7 +493,8 @@
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -1848,6 +1849,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -2282,15 +2284,34 @@
         }
       }
     },
-    "inquirer-autocomplete-prompt": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.0.1.tgz",
-      "integrity": "sha512-Y4V6ifAu9LNrNjcEtYq8YUKhrgmmufUn5fsDQqeWgHY8rEO6ZAQkNUiZtBm2kw2uUQlC9HdgrRCHDhTPPguH5A==",
+    "inquirer-autocomplete-prompt-ipt": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt-ipt/-/inquirer-autocomplete-prompt-ipt-2.0.0.tgz",
+      "integrity": "sha512-2qkl1lWeXbFN/O3+xdqJUdMfnNirvWKqgsgmhOjpOiVCcnJf+XYSEjFfdTgk+MDTtVt5AZiWR9Ji+f4YsWBdUw==",
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "figures": "^2.0.0",
-        "run-async": "^2.3.0"
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^2.4.2",
+        "figures": "^3.1.0",
+        "run-async": "^2.3.0",
+        "rxjs": "^6.5.3"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
+        "figures": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        }
       }
     },
     "irregular-plurals": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "cli-width": "^2.2.0",
     "clipboardy": "^2.1.0",
-    "extract-path": "^1.0.0",
+    "extract-path": "^2.0.0",
     "fuzzysearch": "^1.0.3",
     "get-stdin": "^7.0.0",
     "inquirer": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "src/index.js",
   "man": "./man/doc.1",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10"
   },
   "scripts": {
     "pretest": "eslint src/*.js",

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "inquirer": "^7.0.0",
     "inquirer-autocomplete-prompt-ipt": "^2.0.0",
     "reopen-tty": "^1.1.2",
-    "yargs": "^14.0.0"
+    "yargs": "^14.2.0"
   },
   "devDependencies": {
     "ava": "^2.4.0",
     "eslint": "^6.5.1",
-    "eslint-config-prettier": "^6.3.0",
+    "eslint-config-prettier": "^6.4.0",
     "lodash.template": "^4.5.0",
     "mock-require": "^3.0.1",
     "prettier": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fuzzysearch": "^1.0.3",
     "get-stdin": "^7.0.0",
     "inquirer": "^7.0.0",
-    "inquirer-autocomplete-prompt": "^1.0.1",
+    "inquirer-autocomplete-prompt-ipt": "^2.0.0",
     "reopen-tty": "^1.1.2",
     "yargs": "^14.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ function iPipeTo(
 	if (options.autocomplete) {
 		prompt.registerPrompt(
 			"autocomplete",
-			require("inquirer-autocomplete-prompt")
+			require("inquirer-autocomplete-prompt-ipt")
 		);
 	}
 


### PR DESCRIPTION
- Updated `yargs@14.2.0`
- Updated `eslint-config-prettier@6.4.0`
- Moved to `inquirer-autocomplete-prompt-ipt` fork in order to better support sub dependencies updates and overall maintenance of the package