### PR TITLE
trim on printed width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3848,22 +3848,36 @@
       "dev": true
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -4295,6 +4309,27 @@
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "inquirer": "^7.0.0",
     "inquirer-autocomplete-prompt-ipt": "^2.0.0",
     "reopen-tty": "^1.1.2",
+    "string-width": "~4.2.0",
     "yargs": "^15.0.2"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function iPipeTo(
 
 		let attempts = 0
 		while (stringWidth(str) > maxWidth) {
-			// TODO trim until shorter than maxWidth
+			// trim until shorter than maxWidth
 			str = str.substr(0, maxWidth - ++attempts)
 		}
 		str += "..."

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,12 @@ const cliWidth = require("cli-width");
 const inquirer = require("inquirer");
 const fuzzysearch = require("fuzzysearch");
 
+/* get actual width of string
+ * some text ex. 夢 are 2 characters wide but still 1 character
+ * in length.
+ */
+const stringWidth = require("string-width")
+
 function iPipeTo(
 	input,
 	{ stdin = process.stdin, stdout = process.stdout, ...options },
@@ -26,7 +32,14 @@ function iPipeTo(
 
 	function trim(str) {
 		const maxWidth = cliWidth({ defaultWidth: 80, output: stdout }) - 9;
-		return str.length > maxWidth ? str.substr(0, maxWidth) + "..." : str;
+
+		let attempts = 0
+		while (stringWidth(str) > maxWidth) {
+			// TODO trim until shorter than maxWidth
+			str = str.substr(0, maxWidth - ++attempts)
+		}
+		str += "..."
+		return str
 	}
 
 	function getDefaultChoices(promptType) {


### PR DESCRIPTION
Trim based on printed width instead of text length ( using `string-width` npm module )

Some text ( ex. 世界の夢 ) have text.length of 4 but printed width of 8.